### PR TITLE
documentation improved and changed mispelled function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-# Substrate Node Template
+# Liberland - Blockchain Node
 
-[![Try on playground](https://img.shields.io/badge/Playground-Node_Template-brightgreen?logo=Parity%20Substrate)](https://playground.substrate.dev/?deploy=node-template)
+This is the official blockchain node of [Liberland](https://liberland.org)  
 
-A fresh FRAME-based [Substrate](https://www.substrate.io/) node, ready for hacking :rocket:
 
 ## Getting Started
 
-Follow the steps below to get started with the Node Template, or get it up and running right from your browser
-in just a few clicks using [Playground](https://playground.substrate.dev/) :hammer_and_wrench:
+Follow the steps below to get started with the Node, or get it up and running right from your browser
+
 
 ### Using Nix
 
@@ -41,7 +40,7 @@ Once the project has been built, the following command can be used to explore al
 subcommands:
 
 ```sh
-./target/release/node-template -h
+./target/release/liberland_node -h
 ```
 
 ## Run
@@ -55,19 +54,19 @@ node.
 This command will start the single-node development chain with persistent state:
 
 ```bash
-./target/release/node-template --dev
+./target/release/liberland_node --dev
 ```
 
 Purge the development chain's state:
 
 ```bash
-./target/release/node-template purge-chain --dev
+./target/release/liberland_node purge-chain --dev
 ```
 
 Start the development chain with detailed logging:
 
 ```bash
-RUST_LOG=debug RUST_BACKTRACE=1 ./target/release/node-template -lruntime=debug --dev
+RUST_LOG=debug RUST_BACKTRACE=1 ./target/release/liberland_node -lruntime=debug --dev
 ```
 
 ### Connect with Polkadot-JS Apps Front-end
@@ -80,10 +79,6 @@ to interact with your chain. [Click here](https://polkadot.js.org/apps/#/explore
 If you want to see the multi-node consensus algorithm in action, refer to
 [our Start a Private Network tutorial](https://substrate.dev/docs/en/tutorials/start-a-private-network/).
 
-## Template Structure
-
-A Substrate project such as this consists of a number of components that are spread across a few
-directories.
 
 ### Node
 
@@ -123,7 +118,7 @@ After the node has been [built](#build), refer to the embedded documentation to 
 capabilities and configuration parameters that it exposes:
 
 ```shell
-./target/release/node-template --help
+./target/release/liberland_node --help
 ```
 
 ### Runtime
@@ -183,15 +178,15 @@ Then run the following command to start a single node development chain.
 ```
 
 This command will firstly compile your code, and then start a local development network. You can
-also replace the default command (`cargo build --release && ./target/release/node-template --dev --ws-external`)
+also replace the default command (`cargo build --release && ./target/release/liberland_node --dev --ws-external`)
 by appending your own. A few useful ones are as follow.
 
 ```bash
 # Run Substrate node without re-compiling
-./scripts/docker_run.sh ./target/release/node-template --dev --ws-external
+./scripts/docker_run.sh ./target/release/liberland_node --dev --ws-external
 
 # Purge the local dev chain
-./scripts/docker_run.sh ./target/release/node-template purge-chain --dev
+./scripts/docker_run.sh ./target/release/liberland_node purge-chain --dev
 
 # Check whether the code is compilable
 ./scripts/docker_run.sh cargo check

--- a/node/src/identity_rpc.rs
+++ b/node/src/identity_rpc.rs
@@ -14,8 +14,8 @@ pub trait IdentityRpc {
     #[rpc(name = "check_id_identity")]
     fn check_id_identity(&self, id: PassportId, id_type: IdentityType) -> Result<bool>;
 
-    #[rpc(name = "check_account_indetity")]
-    fn check_account_indetity(&self, account: AccountId, id_type: IdentityType) -> Result<bool>;
+    #[rpc(name = "check_account_identity")]
+    fn check_account_identity(&self, account: AccountId, id_type: IdentityType) -> Result<bool>;
 }
 
 pub struct IdentityRpcImpl<C> {
@@ -36,11 +36,11 @@ where
         Ok(res)
     }
 
-    fn check_account_indetity(&self, account: AccountId, id_type: IdentityType) -> Result<bool> {
+    fn check_account_identity(&self, account: AccountId, id_type: IdentityType) -> Result<bool> {
         let api = self.client.runtime_api();
         let best_hash = BlockId::hash(self.client.info().best_hash);
         let res = api
-            .check_account_indetity(&best_hash, account, id_type)
+            .check_account_identity(&best_hash, account, id_type)
             .unwrap();
         Ok(res)
     }

--- a/pallets/assembly/src/lib.rs
+++ b/pallets/assembly/src/lib.rs
@@ -212,7 +212,7 @@ pub mod pallet {
         pub fn vote(origin: OriginFor<T>, ballot: AltVote) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::IdentTrait::check_account_indetity(sender.clone(), IdentityType::Citizen),
+                T::IdentTrait::check_account_identity(sender.clone(), IdentityType::Citizen),
                 <Error<T>>::AccountCannotVote
             );
             //this unwrap() is correct
@@ -244,7 +244,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::IdentTrait::check_account_indetity(sender.clone(), IdentityType::Assembly),
+                T::IdentTrait::check_account_identity(sender.clone(), IdentityType::Assembly),
                 <Error<T>>::AccountCannotVote
             );
             //this unwrap() is correct
@@ -315,7 +315,7 @@ pub mod pallet {
                 <Error<T>>::LifeTimeIsLessThanLaws
             );
             ensure!(
-                T::IdentTrait::check_account_indetity(sender, IdentityType::Assembly),
+                T::IdentTrait::check_account_identity(sender, IdentityType::Assembly),
                 <Error<T>>::AccountCannotProposeLaw
             );
             T::VotingTrait::create_voting(
@@ -341,7 +341,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::IdentTrait::check_account_indetity(sender.clone(), IdentityType::Assembly),
+                T::IdentTrait::check_account_identity(sender.clone(), IdentityType::Assembly),
                 <Error<T>>::AccountCannotVote
             );
 
@@ -376,7 +376,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::IdentTrait::check_account_indetity(sender.clone(), IdentityType::Citizen),
+                T::IdentTrait::check_account_identity(sender.clone(), IdentityType::Citizen),
                 <Error<T>>::AccountCannotSupport
             );
             let assemblies = <CurrentAssembliesList<T>>::get();

--- a/pallets/identity/README.md
+++ b/pallets/identity/README.md
@@ -1,1 +1,5 @@
 # Identification pallet
+This module identify the citizens of Liberland storing  the association between a passport id and and an account on the blockchain.   
+The storing of such identification is reserved to delegate account with the authorization to identify the citizens.  
+
+

--- a/pallets/min-of-interior/src/lib.rs
+++ b/pallets/min-of-interior/src/lib.rs
@@ -107,7 +107,7 @@ pub mod pallet {
             let sender = ensure_signed(origin)?;
 
             ensure!(
-                T::IdentityTrait::check_account_indetity(sender, IdentityType::MinisterOfInterior),
+                T::IdentityTrait::check_account_identity(sender, IdentityType::MinisterOfInterior),
                 <Error<T>>::AccountCannotProcessKyc
             );
 
@@ -134,7 +134,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::IdentityTrait::check_account_indetity(sender.clone(), IdentityType::EResident),
+                T::IdentityTrait::check_account_identity(sender.clone(), IdentityType::EResident),
                 <Error<T>>::EresidenceNotFound
             );
             let pasport_id = pallet_identity::Pallet::<T>::passport_id(sender.clone()).unwrap();
@@ -149,7 +149,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::IdentityTrait::check_account_indetity(sender, IdentityType::MinisterOfInterior),
+                T::IdentityTrait::check_account_identity(sender, IdentityType::MinisterOfInterior),
                 <Error<T>>::OnlyMinistryOfInteriorCall
             );
 
@@ -171,7 +171,7 @@ pub mod pallet {
             let sender = ensure_signed(origin)?;
 
             ensure!(
-                T::IdentityTrait::check_account_indetity(sender, IdentityType::MinisterOfInterior),
+                T::IdentityTrait::check_account_identity(sender, IdentityType::MinisterOfInterior),
                 <Error<T>>::OnlyMinistryOfInteriorCall
             );
             if approved {

--- a/pallets/referendum/src/lib.rs
+++ b/pallets/referendum/src/lib.rs
@@ -100,7 +100,7 @@ pub mod pallet {
             let sender = ensure_signed(origin)?;
 
             ensure!(
-                T::IdentityTrait::check_account_indetity(sender, IdentityType::Citizen),
+                T::IdentityTrait::check_account_identity(sender, IdentityType::Citizen),
                 <Error<T>>::AccountCannotSuggestPetition,
             );
 
@@ -120,7 +120,7 @@ pub mod pallet {
             let sender = ensure_signed(origin)?;
 
             ensure!(
-                T::IdentityTrait::check_account_indetity(sender.clone(), IdentityType::Citizen),
+                T::IdentityTrait::check_account_identity(sender.clone(), IdentityType::Citizen),
                 <Error<T>>::AccountCannotVote,
             );
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
+authors = ['LiberLand <https://github.com/liberland/liberland_node>']
 edition = '2018'
-homepage = 'https://substrate.dev'
+homepage = 'https://liberland.org'
 license = 'Unlicense'
 name = 'liberland-node-runtime'
-repository = 'https://github.com/substrate-developer-hub/substrate-node-template/'
+repository = 'https://github.com/liberland/liberland_node'
 version = '3.0.0'
 
 [package.metadata.docs.rs]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -109,8 +109,8 @@ pub mod opaque {
 // To learn more about runtime versioning and what each of the following value means:
 //   https://substrate.dev/docs/en/knowledgebase/runtime/upgrades#runtime-versioning
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: create_runtime_str!("node-template"),
-    impl_name: create_runtime_str!("node-template"),
+    spec_name: create_runtime_str!("liberland-node"),
+    impl_name: create_runtime_str!("liberland-node"),
     authoring_version: 1,
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
@@ -735,8 +735,8 @@ impl_runtime_apis! {
             IdentityPallet::check_id_identity(id, id_type)
         }
 
-        fn check_account_indetity(account: AccountId, id_type: pallet_identity::IdentityType) -> bool {
-            IdentityPallet::check_account_indetity(account, id_type)
+        fn check_account_identity(account: AccountId, id_type: pallet_identity::IdentityType) -> bool {
+            IdentityPallet::check_account_identity(account, id_type)
         }
     }
 


### PR DESCRIPTION
Improved the current documentation on README files, added some comment in the source code of the identity pallet and renamed a misspelled function everywhere it was called. The UI may require a minor change to match the renamed function.